### PR TITLE
Add hint to Python-based JEXL parser and evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ the returned Promise will already have a `.catch()` attached to it.
 Removes a binary or unary operator from the Jexl instance. For example, "^" can
 be passed to eliminate the "power of" operator.
 
+## Other implementations
+
+[PyJEXL](https://github.com/mozilla/pyjexl) - A Python-based JEXL parser and evaluator.
+
 ## License
 Jexl is licensed under the MIT license. Please see `LICENSE.txt` for full
 details.


### PR DESCRIPTION
When someone is considering using JEXL it might be important to note that there are implementations in other languages as well.

Especially helpful when the same expression needs to be evaluated in backend (which might be written e.g. Python) and JavaScript frontend. This makes JEXL even more useful than it already is.