### PR TITLE
Fix issue with matching escaped quotes at the end of strings

### DIFF
--- a/__tests__/lib/Lexer.test.js
+++ b/__tests__/lib/Lexer.test.js
@@ -31,8 +31,20 @@ describe('Lexer', () => {
       expect(elems).toHaveLength(1)
       expect(elems[0]).toEqual(str)
     })
+    it('supports escaped double-quotes at the end of strings', () => {
+      const str = '"foo\\""'
+      const elems = inst.getElements(str)
+      expect(elems).toHaveLength(1)
+      expect(elems[0]).toEqual(str)
+    })
     it('supports escaping single-quotes', () => {
       const str = "'f\\'oo'"
+      const elems = inst.getElements(str)
+      expect(elems).toHaveLength(1)
+      expect(elems[0]).toEqual(str)
+    })
+    it('supports escaped single-quotes at the end of strings', () => {
+      const str = "'foo\\''"
       const elems = inst.getElements(str)
       expect(elems).toHaveLength(1)
       expect(elems[0]).toEqual(str)

--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -8,8 +8,8 @@ const identRegex = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
 const escEscRegex = /\\\\/
 const preOpRegexElems = [
   // Strings
-  "'(?:(?:\\\\')?[^'])*'",
-  '"(?:(?:\\\\")?[^"])*"',
+  "'(?:(?:\\\\')|[^'])*'",
+  '"(?:(?:\\\\")|[^"])*"',
   // Whitespace
   '\\s+',
   // Booleans


### PR DESCRIPTION
I fixed this issue downstream in https://github.com/mozilla/mozjexl/pull/23.