### PR TITLE
Re-add support for arbitrary whitespace in expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Transform errors did not always get thrown when using `evalSync` (#55, #56)
   (@bitghostm)
+- Arbitrary whitespace is now re-supported (#54) (@czosel)
 
 ## [v2.1.1]
 

--- a/__tests__/lib/evaluator/Evaluator.test.js
+++ b/__tests__/lib/evaluator/Evaluator.test.js
@@ -165,4 +165,8 @@ describe('Evaluator', () => {
     const e = new Evaluator(grammar, null, { a: {}, d: 4 })
     return expect(e.eval(toTree('a.b[.c == d]'))).resolves.toHaveLength(0)
   })
+  it('should handle an expression with arbitrary whitespace', function () {
+    const e = new Evaluator(grammar)
+    return expect(e.eval(toTree('(\t2\n+\n3) *\n4\n\r\n'))).resolves.toBe(20)
+  })
 })

--- a/__tests__/lib/parser/Parser.test.js
+++ b/__tests__/lib/parser/Parser.test.js
@@ -482,4 +482,13 @@ describe('Parser', () => {
       }
     })
   })
+  it('should handle whitespace in an expression', function () {
+    inst.addTokens(lexer.tokenize('\t2\r\n+\n\r3\n\n'))
+    expect(inst.complete()).toEqual({
+      type: 'BinaryExpression',
+      operator: '+',
+      left: { type: 'Literal', value: 2 },
+      right: { type: 'Literal', value: 3 }
+    })
+  })
 })

--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -218,10 +218,8 @@ class Lexer {
    * @private
    */
   _isWhitespace (str) {
-    for (let i = 0; i < str.length; i++) {
-      if (str[i] !== ' ') return false
-    }
-    return true
+    const whitespaceRegex = /^\s*$/
+    return whitespaceRegex.test(str)
   }
 
   /**


### PR DESCRIPTION
Hi @TomFrost 

First of all, thank you for your work on this excellent project! :pray: 

This fix has already been added in https://github.com/TomFrost/Jexl/pull/19, but seems to have been lost during the merge of 2.0. This is just repeating the same change while adapting it to the updated code style.