### PR TITLE
Latin 1 Supplement letter support for identifiers

### DIFF
--- a/__tests__/lib/Lexer.test.js
+++ b/__tests__/lib/Lexer.test.js
@@ -64,6 +64,11 @@ describe('Lexer', () => {
       const elems = inst.getElements(str)
       expect(elems).toEqual([str])
     })
+    it('allows an identifier to start with and contain accented letters from Latin 1 Supplement unicode block', () => {
+      const str = 'ÄmyäVarÖö'
+      const elems = inst.getElements(str)
+      expect(elems).toEqual([str])
+    })
   })
   describe('Tokens', () => {
     it('unquotes string elements', () => {

--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -4,7 +4,7 @@
  */
 
 const numericRegex = /^-?(?:(?:[0-9]*\.[0-9]+)|[0-9]+)$/
-const identRegex = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+const identRegex = /^[a-zA-Z_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$][a-zA-Z0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$]*$/
 const escEscRegex = /\\\\/
 const whitespaceRegex = /^\s*$/
 const preOpRegexElems = [
@@ -19,7 +19,7 @@ const preOpRegexElems = [
 ]
 const postOpRegexElems = [
   // Identifiers
-  '[a-zA-Z_\\$][a-zA-Z0-9_\\$]*',
+  '[a-zA-Z_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\\$][a-zA-Z0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\\$]*',
   // Numerics (without negative symbol)
   '(?:(?:[0-9]*\\.[0-9]+)|[0-9]+)'
 ]


### PR DESCRIPTION
This change allows the identifiers to contain Latin 1 Supplement
unicode block's lower part, namely the accented letters often used
for example in Scandinavian countries. Doesn't contain control
characters, symbols or punctuations.