### PR TITLE
Allow transforms that match Object.prototype methods

### DIFF
--- a/__tests__/lib/evaluator/Evaluator.test.js
+++ b/__tests__/lib/evaluator/Evaluator.test.js
@@ -59,6 +59,12 @@ describe('Evaluator', () => {
     const e = new Evaluator(grammar, { half: half }, context)
     return expect(e.eval(toTree('foo|half + 3'))).resolves.toBe(8)
   })
+  it('allows using toString as a transform', async () => {
+    const context = { foo: 10 }
+    const toString = val => JSON.stringify(val)
+    const e = new Evaluator(grammar, { toString: toString }, context)
+    return expect(e.eval(toTree('foo|toString'))).resolves.toBe('10')
+  })
   it('filters arrays', async () => {
     const context = {
       foo: {

--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -150,7 +150,7 @@ class Lexer {
       token.value = parseFloat(element)
     } else if (element === 'true' || element === 'false') {
       token.value = element === 'true'
-    } else if (this._grammar[element]) {
+    } else if (Object.prototype.hasOwnProperty.call(this._grammar, element)) {
       token.type = this._grammar[element].type
     } else if (element.match(identRegex)) {
       token.type = 'identifier'


### PR DESCRIPTION
For example, this allows specifying `foo|toString` or `foo|valueOf`. Previously this would error due to a syntax error.