### PR TITLE
Fix bug when escaping '\\'

### DIFF
--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -5,7 +5,7 @@
 
 const numericRegex = /^-?(?:(?:[0-9]*\.[0-9]+)|[0-9]+)$/
 const identRegex = /^[a-zA-Zа-яА-Я_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$][a-zA-Zа-яА-Я0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$]*$/
-const escEscRegex = /\\\\/
+const escEscRegex = /\\\\/g
 const whitespaceRegex = /^\s*$/
 const preOpRegexElems = [
   // Strings


### PR DESCRIPTION
The original version only replace ONE '\\', if the string has more than one '\\', the code won't escape them.
Add 'g' flag to the escQuoteRegex.