### PR TITLE
fix: empty array does not throw error when traversing

### DIFF
--- a/__tests__/lib/evaluator/Evaluator.test.js
+++ b/__tests__/lib/evaluator/Evaluator.test.js
@@ -80,6 +80,15 @@ describe('Evaluator', () => {
     const e = new Evaluator(grammar, context)
     return expect(e.eval(toTree('foo.bar.tek.hello'))).resolves.toBe('world')
   })
+  it('empty array does not throw error when traversing', async () => {
+    const context = {
+      foo: {
+        bar: []
+      }
+    }
+    const e = new Evaluator(grammar, context)
+    return expect(e.eval(toTree('foo.bar.tek.hello'))).resolves.toBe(undefined)
+  })
   it('makes array elements addressable by index', async () => {
     const context = {
       foo: {

--- a/lib/evaluator/handlers.js
+++ b/lib/evaluator/handlers.js
@@ -100,11 +100,11 @@ exports.Identifier = function (ast) {
     return ast.relative ? this._relContext[ast.value] : this._context[ast.value]
   }
   return this.eval(ast.from).then((context) => {
-    if (context === undefined || context === null) {
-      return undefined
-    }
     if (Array.isArray(context)) {
       context = context[0]
+    }
+    if (context === undefined || context === null) {
+      return undefined
     }
     return context[ast.value]
   })


### PR DESCRIPTION
When travers a property in empty array, TypeError would be thrown

````javascript
const context = {
  foo: {
    bar: []
  }
}


// before
// 'foo.bar.tek.hello' --> [TypeError: Cannot read property 'tek' of undefined]

// after
// 'foo.bar.tek.hello' --> undefined
````