### PR TITLE
Add support for literals as object keys

### DIFF
--- a/__tests__/lib/parser/Parser.test.js
+++ b/__tests__/lib/parser/Parser.test.js
@@ -150,6 +150,21 @@ describe('Parser', () => {
       }
     })
   })
+  it('handles dashes in key', () => {
+    inst.addTokens(lexer.tokenize(`{'with-dash': "bar", tek: 1+2}`))
+    expect(inst.complete()).toEqual({
+      type: 'ObjectLiteral',
+      value: {
+        'with-dash': { type: 'Literal', value: 'bar' },
+        tek: {
+          type: 'BinaryExpression',
+          operator: '+',
+          left: { type: 'Literal', value: 1 },
+          right: { type: 'Literal', value: 2 }
+        }
+      }
+    })
+  })
   it('handles nested object literals', () => {
     inst.addTokens(lexer.tokenize('{foo: {bar: "tek"}}'))
     expect(inst.complete()).toEqual({

--- a/lib/parser/states.js
+++ b/lib/parser/states.js
@@ -65,6 +65,7 @@ exports.states = {
   },
   expectObjKey: {
     tokenTypes: {
+      literal: { toState: 'expectKeyValSep', handler: h.objKey },
       identifier: { toState: 'expectKeyValSep', handler: h.objKey },
       closeCurl: { toState: 'expectBinOp' }
     }


### PR DESCRIPTION
Firstly, thanks for this great library!

I have a requirement for users to be able to remap the context to new a new object. For example:

`const context = {
   a: 1,
   b: 2,
}` 

They might map to a new object using the JEXL expression:

` { newKey: a, newKey2: b * 2}`

However the target object is completely user configurable (it's for a metadata/form system) and so they often use dashes in the key, which JEXL does not support (but Javascript does).

I have added support for literals after an open bracket so that users can write

`{ 'new-key': a, 'new-key-2': b * 2}`

I have added a test and all existing tests pass.

Thanks in advance!