### PR TITLE
Updated escEscRegex to handle backslash globally

### DIFF
--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -5,7 +5,7 @@
 
 const numericRegex = /^-?(?:(?:[0-9]*\.[0-9]+)|[0-9]+)$/
 const identRegex = /^[a-zA-Zа-яА-Я_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$][a-zA-Zа-яА-Я0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$]*$/
-const escEscRegex = /\\\\/
+const escEscRegex = /\\\\/g
 const whitespaceRegex = /^\s*$/
 const preOpRegexElems = [
   // Strings


### PR DESCRIPTION
Please check the sequence:
```
let exp = "\"c:\\foo\\bar\"";

let ast = jexl.compile(exp)._getAst();
console.log(ast) //{"type": "Literal", "value": "c:\\foo\\bar"}

exp = jexlExpressionStringFromAst(jexl._grammar, ast) 
console.log(exp) //"c:\\foo\\bar"

ast = jexl.compile(exp)._getAst();
console.log(ast) //{"type": "Literal", "value": "c:\\foo\\\\bar"}

exp = jexlExpressionStringFromAst(jexl._grammar, ast) 
console.log(exp) //"c:\\foo\\\\bar"
```
If we check only first backslash is getting unescaped.

Fix:
Make var escEscRegex = /\\/; to var escEscRegex = /\\/g; In Lexer.js