### PR TITLE
Add a link to the Salesforce Apex implementation of the same.

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ map is optional.
 ## Other implementations
 
 [PyJEXL](https://github.com/mozilla/pyjexl) - A Python-based JEXL parser and evaluator.
+[JexlApex](https://github.com/the-last-byte/JexlApex) - A Salesforce Apex JEXL parser and evaluator.
 
 ## License
 


### PR DESCRIPTION
Added a link to Apex Jexl for Salesforce server-side usage (to match the client-side LWC possibility).